### PR TITLE
move dev dependencies to an appropriate section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+unit-tests.xml

--- a/package.json
+++ b/package.json
@@ -16,13 +16,11 @@
   ],
   "author": "piotr.fryga@allegrogroup.com",
   "license": "MIT",
-  "dependencies": {
+  "devDependencies": {
+    "babel-register": "^6.7.2",
     "mocha": "^2.4.5",
     "mocha-junit-reporter": "^1.0.0",
     "mocha-multi": "^0.7.0",
     "should": "^7.0.0"
-  },
-  "devDependencies": {
-    "babel-register": "^6.7.2"
   }
 }


### PR DESCRIPTION
- A bunch of packages that was exclusively used in tests, was incorrectly listed as runtime dependencies. Thus they were installed unnecessarily every time this package was used as a direct or indirect dependency.
- This change moves it to appropriate section.